### PR TITLE
Build against pitest 1.8.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,8 @@
 		<junit.platform.version>1.8.0</junit.platform.version>
 		<junit.version>5.8.0</junit.version>
 		<mockito.version>2.7.6</mockito.version>
-		<pitest.version>1.7.4</pitest.version>
+		<pitest.version>1.8.0</pitest.version>
+		<asm.version>9.3</asm.version>
 	</properties>
 
 	<scm>
@@ -167,6 +168,24 @@
 			<artifactId>pitest</artifactId>
 			<version>${pitest.version}</version>
 			<type>test-jar</type>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.ow2.asm</groupId>
+			<artifactId>asm-util</artifactId>
+			<version>${asm.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.ow2.asm</groupId>
+			<artifactId>asm-analysis</artifactId>
+			<version>${asm.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.thoughtworks.xstream</groupId>
+			<artifactId>xstream</artifactId>
+			<version>1.4.18</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/src/test/java/org/pitest/rv/ABSMutatorTest.java
+++ b/src/test/java/org/pitest/rv/ABSMutatorTest.java
@@ -17,8 +17,6 @@ package org.pitest.rv;
 import org.junit.Before;
 import org.junit.Test;
 import org.pitest.mutationtest.engine.Mutant;
-import org.pitest.mutationtest.engine.gregor.MutatorTestBase;
-import org.pitest.mutationtest.engine.gregor.mutators.rv.ABSMutator;
 
 import java.util.concurrent.Callable;
 

--- a/src/test/java/org/pitest/rv/AOD1MutatorTest.java
+++ b/src/test/java/org/pitest/rv/AOD1MutatorTest.java
@@ -17,8 +17,6 @@ package org.pitest.rv;
 import org.junit.Before;
 import org.junit.Test;
 import org.pitest.mutationtest.engine.Mutant;
-import org.pitest.mutationtest.engine.gregor.MutatorTestBase;
-import org.pitest.mutationtest.engine.gregor.mutators.rv.AOD1Mutator;
 
 import java.util.concurrent.Callable;
 

--- a/src/test/java/org/pitest/rv/AOD2MutatorTest.java
+++ b/src/test/java/org/pitest/rv/AOD2MutatorTest.java
@@ -17,8 +17,6 @@ package org.pitest.rv;
 import org.junit.Before;
 import org.junit.Test;
 import org.pitest.mutationtest.engine.Mutant;
-import org.pitest.mutationtest.engine.gregor.MutatorTestBase;
-import org.pitest.mutationtest.engine.gregor.mutators.rv.AOD2Mutator;
 
 import java.util.concurrent.Callable;
 

--- a/src/test/java/org/pitest/rv/AOR1MutatorTest.java
+++ b/src/test/java/org/pitest/rv/AOR1MutatorTest.java
@@ -17,8 +17,6 @@ package org.pitest.rv;
 import org.junit.Before;
 import org.junit.Test;
 import org.pitest.mutationtest.engine.Mutant;
-import org.pitest.mutationtest.engine.gregor.MutatorTestBase;
-import org.pitest.mutationtest.engine.gregor.mutators.rv.AOR1Mutator;
 
 import java.util.concurrent.Callable;
 

--- a/src/test/java/org/pitest/rv/AOR2MutatorTest.java
+++ b/src/test/java/org/pitest/rv/AOR2MutatorTest.java
@@ -17,8 +17,6 @@ package org.pitest.rv;
 import org.junit.Before;
 import org.junit.Test;
 import org.pitest.mutationtest.engine.Mutant;
-import org.pitest.mutationtest.engine.gregor.MutatorTestBase;
-import org.pitest.mutationtest.engine.gregor.mutators.rv.AOR2Mutator;
 
 import java.util.concurrent.Callable;
 

--- a/src/test/java/org/pitest/rv/AOR3MutatorTest.java
+++ b/src/test/java/org/pitest/rv/AOR3MutatorTest.java
@@ -17,8 +17,6 @@ package org.pitest.rv;
 import org.junit.Before;
 import org.junit.Test;
 import org.pitest.mutationtest.engine.Mutant;
-import org.pitest.mutationtest.engine.gregor.MutatorTestBase;
-import org.pitest.mutationtest.engine.gregor.mutators.rv.AOR3Mutator;
 
 import java.util.concurrent.Callable;
 

--- a/src/test/java/org/pitest/rv/AOR4MutatorTest.java
+++ b/src/test/java/org/pitest/rv/AOR4MutatorTest.java
@@ -17,8 +17,6 @@ package org.pitest.rv;
 import org.junit.Before;
 import org.junit.Test;
 import org.pitest.mutationtest.engine.Mutant;
-import org.pitest.mutationtest.engine.gregor.MutatorTestBase;
-import org.pitest.mutationtest.engine.gregor.mutators.rv.AOR4Mutator;
 
 import java.util.concurrent.Callable;
 

--- a/src/test/java/org/pitest/rv/CRCR1Test.java
+++ b/src/test/java/org/pitest/rv/CRCR1Test.java
@@ -18,8 +18,6 @@ package org.pitest.rv;
 import org.junit.Before;
 import org.junit.Test;
 import org.pitest.mutationtest.engine.Mutant;
-import org.pitest.mutationtest.engine.gregor.MutatorTestBase;
-import org.pitest.mutationtest.engine.gregor.mutators.rv.CRCR1Mutator;
 
 import java.util.concurrent.Callable;
 

--- a/src/test/java/org/pitest/rv/CRCR2Test.java
+++ b/src/test/java/org/pitest/rv/CRCR2Test.java
@@ -18,8 +18,6 @@ package org.pitest.rv;
 import org.junit.Before;
 import org.junit.Test;
 import org.pitest.mutationtest.engine.Mutant;
-import org.pitest.mutationtest.engine.gregor.MutatorTestBase;
-import org.pitest.mutationtest.engine.gregor.mutators.rv.CRCR2Mutator;
 
 import java.util.concurrent.Callable;
 

--- a/src/test/java/org/pitest/rv/CRCR3Test.java
+++ b/src/test/java/org/pitest/rv/CRCR3Test.java
@@ -18,8 +18,6 @@ package org.pitest.rv;
 import org.junit.Before;
 import org.junit.Test;
 import org.pitest.mutationtest.engine.Mutant;
-import org.pitest.mutationtest.engine.gregor.MutatorTestBase;
-import org.pitest.mutationtest.engine.gregor.mutators.rv.CRCR3Mutator;
 
 import java.util.concurrent.Callable;
 

--- a/src/test/java/org/pitest/rv/CRCR4Test.java
+++ b/src/test/java/org/pitest/rv/CRCR4Test.java
@@ -18,8 +18,6 @@ package org.pitest.rv;
 import org.junit.Before;
 import org.junit.Test;
 import org.pitest.mutationtest.engine.Mutant;
-import org.pitest.mutationtest.engine.gregor.MutatorTestBase;
-import org.pitest.mutationtest.engine.gregor.mutators.rv.CRCR4Mutator;
 
 import java.util.concurrent.Callable;
 

--- a/src/test/java/org/pitest/rv/CRCR5Test.java
+++ b/src/test/java/org/pitest/rv/CRCR5Test.java
@@ -18,8 +18,6 @@ package org.pitest.rv;
 import org.junit.Before;
 import org.junit.Test;
 import org.pitest.mutationtest.engine.Mutant;
-import org.pitest.mutationtest.engine.gregor.MutatorTestBase;
-import org.pitest.mutationtest.engine.gregor.mutators.rv.CRCR5Mutator;
 
 import java.util.concurrent.Callable;
 

--- a/src/test/java/org/pitest/rv/CRCR6Test.java
+++ b/src/test/java/org/pitest/rv/CRCR6Test.java
@@ -18,8 +18,6 @@ package org.pitest.rv;
 import org.junit.Before;
 import org.junit.Test;
 import org.pitest.mutationtest.engine.Mutant;
-import org.pitest.mutationtest.engine.gregor.MutatorTestBase;
-import org.pitest.mutationtest.engine.gregor.mutators.rv.CRCR6Mutator;
 
 import java.util.concurrent.Callable;
 

--- a/src/test/java/org/pitest/rv/MutatorTestBase.java
+++ b/src/test/java/org/pitest/rv/MutatorTestBase.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright 2010 Henry Coles
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+package org.pitest.rv;
+
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.util.ASMifier;
+import org.objectweb.asm.util.CheckClassAdapter;
+import org.objectweb.asm.util.TraceClassVisitor;
+import org.pitest.classinfo.ClassByteArraySource;
+import org.pitest.classinfo.ClassName;
+import org.pitest.classpath.ClassPathByteArraySource;
+import org.pitest.mutationtest.engine.Mutant;
+import org.pitest.mutationtest.engine.MutationDetails;
+import org.pitest.mutationtest.engine.gregor.GregorMutater;
+import org.pitest.mutationtest.engine.gregor.MethodInfo;
+import org.pitest.mutationtest.engine.gregor.MethodMutatorFactory;
+import org.pitest.simpletest.ExcludedPrefixIsolationStrategy;
+import org.pitest.simpletest.Transformation;
+import org.pitest.simpletest.TransformingClassLoader;
+import org.pitest.util.Unchecked;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+@Deprecated // use org.pitest.verifier.mutants.MutatorVerifierStart instead
+public abstract class MutatorTestBase {
+
+    protected GregorMutater engine;
+
+    protected List<MutationDetails> findMutationsFor(
+            final Class<?> clazz) {
+        return this.engine.findMutations(ClassName.fromClass(clazz));
+    }
+
+    protected void createTesteeWith(final Predicate<MethodInfo> filter,
+                                    final MethodMutatorFactory... mutators) {
+        this.engine = new GregorMutater(new ClassPathByteArraySource(), filter,
+                Arrays.asList(mutators));
+    }
+
+    protected void createTesteeWith(final ClassByteArraySource source,
+                                    final Predicate<MethodInfo> filter,
+                                    final Collection<MethodMutatorFactory> mutators) {
+        this.engine = new GregorMutater(source, filter, mutators);
+    }
+
+    protected void createTesteeWith(final Predicate<MethodInfo> filter,
+                                    final Collection<MethodMutatorFactory> mutators) {
+        createTesteeWith(new ClassPathByteArraySource(), filter, mutators);
+    }
+
+    protected void createTesteeWith(final Predicate<MethodInfo> filter,
+                                    final Collection<String> loggingClasses,
+                                    final Collection<MethodMutatorFactory> mutators) {
+        this.engine = new GregorMutater(new ClassPathByteArraySource(), filter,
+                mutators);
+    }
+
+    protected void createTesteeWith(
+            final Collection<MethodMutatorFactory> mutators) {
+        createTesteeWith(i -> true, mutators);
+    }
+
+    protected void createTesteeWith(final MethodMutatorFactory... mutators) {
+        createTesteeWith(i -> true, mutators);
+    }
+
+    protected <T> void assertMutantCallableReturns(final Callable<T> unmutated,
+                                                   final Mutant mutant, final T expected) throws Exception {
+        assertEquals(expected, mutateAndCall(unmutated, mutant));
+    }
+
+    protected void assertNoMutants(final Class<?> mutee) {
+        final Collection<MutationDetails> actual = findMutationsFor(mutee);
+        assertThat(actual).isEmpty();
+    }
+
+    protected <T> T mutateAndCall(final Callable<T> unmutated, final Mutant mutant) {
+        try {
+            final ClassLoader loader = createClassLoader(mutant);
+            return runInClassLoader(loader, unmutated);
+        } catch (final RuntimeException ex) {
+            throw ex;
+        } catch (final Exception ex) {
+            throw Unchecked.translateCheckedException(ex);
+        }
+    }
+
+    private ClassLoader createClassLoader(final Mutant mutant) throws Exception {
+        return new TransformingClassLoader(
+                createTransformation(mutant), new ExcludedPrefixIsolationStrategy());
+    }
+
+    private Transformation createTransformation(final Mutant mutant) {
+        return (name, bytes) -> {
+            if (name.equals(mutant.getDetails().getClassName().asJavaName())) {
+                return mutant.getBytes();
+            } else {
+                return bytes;
+            }
+        };
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T> T runInClassLoader(final ClassLoader loader,
+                                   final Callable<T> callable) throws Exception {
+        final Callable<T> c = (Callable<T>) XStreamCloning.cloneForLoader(callable,
+                loader);
+        return c.call();
+
+    }
+
+    private Function<MutationDetails, Mutant> createMutant() {
+        return a -> MutatorTestBase.this.engine.getMutation(a.getId());
+    }
+
+    protected Mutant getFirstMutant(final Collection<MutationDetails> actual) {
+        assertFalse("No mutant found", actual.isEmpty());
+        final Mutant mutant = this.engine.getMutation(actual.iterator().next()
+                .getId());
+        verifyMutant(mutant);
+        return mutant;
+    }
+
+    protected Mutant getFirstMutant(final Class<?> mutee) {
+        final Collection<MutationDetails> actual = findMutationsFor(mutee);
+        return getFirstMutant(actual);
+    }
+
+    protected Mutant getNthMutant(final Class<?> mutee, int n) {
+        final Collection<MutationDetails> actual = findMutationsFor(mutee);
+        return getNthMutant(actual, n);
+    }
+
+    protected Mutant getNthMutant(final Collection<MutationDetails> actual, int n) {
+        assertFalse("There are less than " + (n + 1) +" mutants", actual.size() < n + 1 );
+        Iterator<MutationDetails> i = actual.iterator();
+        for (int j = 0; j < n && i.hasNext(); j++) {
+            i.next();
+        }
+        final Mutant mutant = this.engine.getMutation(i.next()
+                .getId());
+        verifyMutant(mutant);
+        return mutant;
+    }
+
+    private void verifyMutant(final Mutant mutant) {
+        // printMutant(mutant);
+        final StringWriter sw = new StringWriter();
+        final PrintWriter pw = new PrintWriter(sw);
+        CheckClassAdapter.verify(new ClassReader(mutant.getBytes()), false, pw);
+        assertTrue(sw.toString(), sw.toString().length() == 0);
+
+    }
+
+    protected void printMutant(final Mutant mutant) {
+        final ClassReader reader = new ClassReader(mutant.getBytes());
+        reader.accept(new TraceClassVisitor(null, new ASMifier(), new PrintWriter(
+                System.out)), ClassReader.EXPAND_FRAMES);
+    }
+
+    protected Predicate<MethodInfo> mutateOnlyCallMethod() {
+        return a -> a.getName().equals("call");
+    }
+
+}

--- a/src/test/java/org/pitest/rv/OBBN1MutatorTest.java
+++ b/src/test/java/org/pitest/rv/OBBN1MutatorTest.java
@@ -3,8 +3,6 @@ package org.pitest.rv;
 import org.junit.Before;
 import org.junit.Test;
 import org.pitest.mutationtest.engine.Mutant;
-import org.pitest.mutationtest.engine.gregor.MutatorTestBase;
-import org.pitest.mutationtest.engine.gregor.mutators.rv.OBBN1Mutator;
 
 import java.util.concurrent.Callable;
 

--- a/src/test/java/org/pitest/rv/OBBN2MutatorTest.java
+++ b/src/test/java/org/pitest/rv/OBBN2MutatorTest.java
@@ -3,8 +3,6 @@ package org.pitest.rv;
 import org.junit.Before;
 import org.junit.Test;
 import org.pitest.mutationtest.engine.Mutant;
-import org.pitest.mutationtest.engine.gregor.MutatorTestBase;
-import org.pitest.mutationtest.engine.gregor.mutators.rv.OBBN2Mutator;
 
 import java.util.concurrent.Callable;
 

--- a/src/test/java/org/pitest/rv/OBBN3MutatorTest.java
+++ b/src/test/java/org/pitest/rv/OBBN3MutatorTest.java
@@ -3,8 +3,6 @@ package org.pitest.rv;
 import org.junit.Before;
 import org.junit.Test;
 import org.pitest.mutationtest.engine.Mutant;
-import org.pitest.mutationtest.engine.gregor.MutatorTestBase;
-import org.pitest.mutationtest.engine.gregor.mutators.rv.OBBN3Mutator;
 
 import java.util.concurrent.Callable;
 

--- a/src/test/java/org/pitest/rv/PitXmlDriver.java
+++ b/src/test/java/org/pitest/rv/PitXmlDriver.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2011 Henry Coles
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+package org.pitest.rv;
+
+import com.thoughtworks.xstream.io.xml.AbstractXppDriver;
+import com.thoughtworks.xstream.io.xml.XmlFriendlyNameCoder;
+import io.github.xstream.mxparser.MXParser;
+import org.xmlpull.v1.XmlPullParser;
+
+/**
+ * Pull parser driver that creates hard coded parser type to avoid clashes with
+ * other pull parser on classpath when code under test uses xstream
+ */
+public class PitXmlDriver extends AbstractXppDriver {
+
+    public PitXmlDriver() {
+        super(new XmlFriendlyNameCoder());
+    }
+
+    @Override
+    protected synchronized XmlPullParser createParser() {
+        return new MXParser();
+    }
+}

--- a/src/test/java/org/pitest/rv/ROR1MutatorTest.java
+++ b/src/test/java/org/pitest/rv/ROR1MutatorTest.java
@@ -17,8 +17,6 @@ package org.pitest.rv;
 import org.junit.Before;
 import org.junit.Test;
 import org.pitest.mutationtest.engine.Mutant;
-import org.pitest.mutationtest.engine.gregor.MutatorTestBase;
-import org.pitest.mutationtest.engine.gregor.mutators.rv.ROR1Mutator;
 
 import java.util.concurrent.Callable;
 

--- a/src/test/java/org/pitest/rv/ROR2MutatorTest.java
+++ b/src/test/java/org/pitest/rv/ROR2MutatorTest.java
@@ -17,8 +17,6 @@ package org.pitest.rv;
 import org.junit.Before;
 import org.junit.Test;
 import org.pitest.mutationtest.engine.Mutant;
-import org.pitest.mutationtest.engine.gregor.MutatorTestBase;
-import org.pitest.mutationtest.engine.gregor.mutators.rv.ROR2Mutator;
 
 import java.util.concurrent.Callable;
 

--- a/src/test/java/org/pitest/rv/ROR3MutatorTest.java
+++ b/src/test/java/org/pitest/rv/ROR3MutatorTest.java
@@ -17,8 +17,6 @@ package org.pitest.rv;
 import org.junit.Before;
 import org.junit.Test;
 import org.pitest.mutationtest.engine.Mutant;
-import org.pitest.mutationtest.engine.gregor.MutatorTestBase;
-import org.pitest.mutationtest.engine.gregor.mutators.rv.ROR3Mutator;
 
 import java.util.concurrent.Callable;
 

--- a/src/test/java/org/pitest/rv/ROR4MutatorTest.java
+++ b/src/test/java/org/pitest/rv/ROR4MutatorTest.java
@@ -17,8 +17,6 @@ package org.pitest.rv;
 import org.junit.Before;
 import org.junit.Test;
 import org.pitest.mutationtest.engine.Mutant;
-import org.pitest.mutationtest.engine.gregor.MutatorTestBase;
-import org.pitest.mutationtest.engine.gregor.mutators.rv.ROR4Mutator;
 
 import java.util.concurrent.Callable;
 

--- a/src/test/java/org/pitest/rv/ROR5MutatorTest.java
+++ b/src/test/java/org/pitest/rv/ROR5MutatorTest.java
@@ -17,8 +17,6 @@ package org.pitest.rv;
 import org.junit.Before;
 import org.junit.Test;
 import org.pitest.mutationtest.engine.Mutant;
-import org.pitest.mutationtest.engine.gregor.MutatorTestBase;
-import org.pitest.mutationtest.engine.gregor.mutators.rv.ROR5Mutator;
 
 import java.util.concurrent.Callable;
 

--- a/src/test/java/org/pitest/rv/UOI1MutatorTest.java
+++ b/src/test/java/org/pitest/rv/UOI1MutatorTest.java
@@ -17,8 +17,6 @@ package org.pitest.rv;
 import org.junit.Before;
 import org.junit.Test;
 import org.pitest.mutationtest.engine.Mutant;
-import org.pitest.mutationtest.engine.gregor.MutatorTestBase;
-import org.pitest.mutationtest.engine.gregor.mutators.rv.UOI1Mutator;
 
 import java.util.concurrent.Callable;
 

--- a/src/test/java/org/pitest/rv/UOI2MutatorTest.java
+++ b/src/test/java/org/pitest/rv/UOI2MutatorTest.java
@@ -17,8 +17,6 @@ package org.pitest.rv;
 import org.junit.Before;
 import org.junit.Test;
 import org.pitest.mutationtest.engine.Mutant;
-import org.pitest.mutationtest.engine.gregor.MutatorTestBase;
-import org.pitest.mutationtest.engine.gregor.mutators.rv.UOI2Mutator;
 
 import java.util.concurrent.Callable;
 

--- a/src/test/java/org/pitest/rv/UOI3MutatorTest.java
+++ b/src/test/java/org/pitest/rv/UOI3MutatorTest.java
@@ -17,8 +17,6 @@ package org.pitest.rv;
 import org.junit.Before;
 import org.junit.Test;
 import org.pitest.mutationtest.engine.Mutant;
-import org.pitest.mutationtest.engine.gregor.MutatorTestBase;
-import org.pitest.mutationtest.engine.gregor.mutators.rv.UOI3Mutator;
 
 import java.util.concurrent.Callable;
 

--- a/src/test/java/org/pitest/rv/UOI4MutatorTest.java
+++ b/src/test/java/org/pitest/rv/UOI4MutatorTest.java
@@ -17,8 +17,6 @@ package org.pitest.rv;
 import org.junit.Before;
 import org.junit.Test;
 import org.pitest.mutationtest.engine.Mutant;
-import org.pitest.mutationtest.engine.gregor.MutatorTestBase;
-import org.pitest.mutationtest.engine.gregor.mutators.rv.UOI4Mutator;
 
 import java.util.concurrent.Callable;
 

--- a/src/test/java/org/pitest/rv/XStreamCloning.java
+++ b/src/test/java/org/pitest/rv/XStreamCloning.java
@@ -1,0 +1,53 @@
+package org.pitest.rv;
+
+import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.io.xml.CompactWriter;
+
+import java.io.StringWriter;
+import java.io.Writer;
+import java.util.WeakHashMap;
+
+import static org.pitest.util.Unchecked.translateCheckedException;
+
+@Deprecated
+public class XStreamCloning {
+
+    private static final XStream                           XSTREAM_INSTANCE          = new XStream(
+            new PitXmlDriver());
+    private static final WeakHashMap<ClassLoader, XStream> CACHE                     = new WeakHashMap<>();
+
+
+    public static Object cloneForLoader(final Object o, final ClassLoader loader) {
+        try {
+            final String xml = toXml(o);
+            final XStream foreignXstream = getXStreamForLoader(loader);
+            return foreignXstream.fromXML(xml);
+        } catch (final Exception ex) {
+            throw translateCheckedException(ex);
+        }
+
+    }
+
+    private static XStream getXStreamForLoader(final ClassLoader loader) {
+        XStream foreginXstream = CACHE.get(loader);
+        if (foreginXstream == null) {
+            foreginXstream = new XStream(new PitXmlDriver());
+            foreginXstream.setClassLoader(loader);
+            XStream.setupDefaultSecurity(foreginXstream);
+            foreginXstream.allowTypesByWildcard(new String[] {"**"});
+            // possible that more than one instance will be created
+            // per loader, but probably better than synchronizing the whole method
+            synchronized (CACHE) {
+                CACHE.put(loader, foreginXstream);
+            }
+        }
+        return foreginXstream;
+    }
+
+    public static String toXml(final Object o) {
+        final Writer writer = new StringWriter();
+        XSTREAM_INSTANCE.marshal(o, new CompactWriter(writer));
+
+        return writer.toString();
+    }
+    }


### PR DESCRIPTION
XStream and the legacy MutatorTestBase class have been removed from
pitest. As the rv tests still depend on them they have been moved into
this repo. Tests should eventually be migrated away from them.