### PR TITLE
Update version number in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ To use the plugin it must be placed on the classpath of the pitest tool (**not**
           <dependency>
             <groupId>org.pitest</groupId>
             <artifactId>pitest-rv-plugin</artifactId>
-            <version>1.0</version>
+            <version>0.1</version>
           </dependency>
         </dependencies>
       </plugin>


### PR DESCRIPTION
The version number [in Maven central](https://central.sonatype.com/artifact/org.pitest/pitest-rv-plugin) is `0.1`, but the README says `1.0`. I have updated the version number. (Addresses #2)

(I know that the plugin is not currently usable with the latest version of PIT (#3) — I am taking a look at that. Pointers appreciated if you have them!)